### PR TITLE
Add ability to use user-specified http.Client.

### DIFF
--- a/cloudatcost/client.go
+++ b/cloudatcost/client.go
@@ -19,8 +19,9 @@ const (
 
 // Option Optional parameters
 type Option struct {
-	Login string
-	Key   string
+	Login  string
+	Key    string
+	Client *http.Client
 }
 
 // ErrorStatus https://github.com/cloudatcost/api Error:
@@ -61,6 +62,10 @@ func (r *ErrorResponse) Error() string {
 // NewClient returns a new CloudAtCost API client.
 func NewClient(option *Option) (*Client, error) {
 	httpClient := http.DefaultClient
+	if option.Client != nil {
+		httpClient = option.Client
+	}
+
 	baseURL, _ := url.Parse(defaultBaseURL)
 
 	c := &Client{client: httpClient, BaseURL: baseURL, UserAgent: userAgent, Option: option}


### PR DESCRIPTION
Requests have been failing with an `509: certificate signed by unknown authority` error since CloudAtCost upgraded their servers.

This PR allows for a non-`http.DefaultClient`, including one that ignores insecure certificates.
